### PR TITLE
K8s manifests

### DIFF
--- a/k8s-manifests/application-manifest.yml
+++ b/k8s-manifests/application-manifest.yml
@@ -24,3 +24,14 @@ spec:
     RollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flask-app-service
+spec:
+  ports:
+    - port: 80
+      targetPort: 5000
+  selector:
+    app: flask-app

--- a/k8s-manifests/application-manifest.yml
+++ b/k8s-manifests/application-manifest.yml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 5000
   strategy:
     type: RollingUpdate
-    RollingUpdate:
+    rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
 ---

--- a/k8s-manifests/application-manifest.yml
+++ b/k8s-manifests/application-manifest.yml
@@ -31,7 +31,8 @@ metadata:
   name: flask-app-service
 spec:
   ports:
-    - port: 80
+    - protocol: TCP
+      port: 80
       targetPort: 5000
   selector:
     app: flask-app

--- a/k8s-manifests/application-manifest.yml
+++ b/k8s-manifests/application-manifest.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flask-app-deployment
+  labels:
+    app: flask-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: flask-app
+  template:
+    metadata:
+      labels:
+        app: flask-app
+    spec:
+      containers:
+      - name: flask-app
+        image: sameem97/flask-track-orders
+        ports:
+        - containerPort: 5000
+  strategy:
+    type: RollingUpdate
+    RollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1


### PR DESCRIPTION
Add kubernetes manifests to provision the necessary kubernetes resources to manage the application. This includes a Deployment with 2 replica pods (each running a containerised instance of the web app) as well as a ClusterIP Service for internal cluster communication.